### PR TITLE
setv: satisfy ewok issue #84

### DIFF
--- a/src/setv/setv_fcn.sh
+++ b/src/setv/setv_fcn.sh
@@ -25,6 +25,20 @@ function _setvcomplete_()
     COMPREPLY=($(compgen -W "$names" -X "$xpat" -- "$word"))
 }
 
+# help info
+#
+# note that there exist some commands not documented here; refer to setv_main.sh
+# as well as functions below that implement these command switches
+#
+# --activate | --deactivate | --create | --populate
+#    create / activate / populate == install
+#
+# --clone
+#    make a copy of a venv
+#
+# --switch
+#    switch to a differenv venv; same as --activate once a venv is installed
+#
 function _setv_help() {
     echo
     echo "Usage: setv options <venv>"
@@ -36,9 +50,6 @@ function _setv_help() {
     echo -n "  --install [--package <pkg-file>] venv"
         echo -e "  install (optionally from <pkg-file>) and activate 'venv'"
     echo -n "  --update --package <pkg-file> venv"
-        echo -e "  update 'venv' from <pkg-file>"
-    # echo -e "  --clone venv clone   clone virtual environment 'venv' into 'clone'"
-    # echo -e "  --switch venv  switch to 'venv'"
     echo -e "  --delete venv  delete virtual environment 'venv'"
 
     echo -n "  --venvdir <dir>  specify virtual environment home location"
@@ -66,6 +77,7 @@ function _setv_checkArg()
 # Determine whether or not a venv is active
 function _setv_invenv()
 {
+    # The following will also work; left here as a placeholder / reminder
     # INVENV=$(python3 -c 'import sys; print ("1" if sys.base_prefix != sys.prefix else "0")')
     INVENV=$(python -c 'import os;  print ("1" if "VIRTUAL_ENV" in os.environ else "0")')
     [[ ! -z $VIRTUAL_ENV && $INVENV -eq 1 ]] && _curr_venv=`basename $VIRTUAL_ENV` || _curr_venv=""
@@ -175,7 +187,7 @@ function _setv_deactivate()
     fi
 }
 
-# Check argument list (from '-p' or '-N') for a specified requirements file
+# Check argument list for a specified requirements file
 function _setv_rqmts_file()
 {
     local args=("$@")

--- a/src/setv/setv_main.sh
+++ b/src/setv/setv_main.sh
@@ -46,7 +46,7 @@ _curr_venv=${VIRTUAL_ENV:-""}
 # Main function
 #
 function setv() {
-    # see setv_fcn/_setv_help() for options
+    # see setv_fcn.sh/_setv_help() for switches / implementation
 
     local opt args cmd
 
@@ -75,7 +75,7 @@ function setv() {
                 return
                 ;;
 
-            --activate | --deactivate | --create | --activate | --populate | --delete)
+            --activate | --deactivate | --create | --populate | --delete)
                     venv=$2
                     if [ "$cmd" == "populate" ]; then
                         _rqmt_file=$3


### PR DESCRIPTION
## Description

setv -- tool for managing python virtual environments.

The JEDI module `setv` is a tool to create and manage virtual environments. As with other JEDI modules, it is loaded as:

`module load setv`

The `--help` option to setv provides a list of available commands:

```
% setv --help

Usage: setv options <venv>
Optional arguments:
  --help  help (show this information)
  --list  list available virtual environments

  --activate venv  activate 'venv'
  --install [--package <pkg-file>] venv  install (optionally from <pkg-file>) and activate 'venv'
  --update --package <pkg-file> venv  update 'venv' from <pkg-file>
  --delete venv  delete virtual environment 'venv'
  --venvdir <dir>  specify virtual environment home location (current: $HOME)
```

The environment variable **SETV_VIRTUAL_ENV_DIR** controls where a venv is created. By default, it's value is set to a user's $HOME. Change the value of this variable if you wish to create a venv in a directory other than $HOME; this location can be changed as:

```
% setv --venvdir <dir>
```

where _\<dir\>_ is the location you choose to host your venv(s).

To create a venv, enter:

```
% setv --install <venv>
```

where _\<venv\>_ is what you wish to call your venv. A venv is created, minimally populated with utilities necessary to get started, and activated. At this point, you're working within the virtual environment _\<venv\>_ that you installed.
 
An optional `<pkg-file>` may be specified when installing a venv; a package file is formatted as a [python requirements file](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format), and will install the specified python packages into your venv.

Adding more  Python packages to a venv may be accomplished by updating a venv; use the `--update` switch:

```
% setv --update --package <pkg-file> <venv>
```

The `--package` switch and `<pkg-file>` argument are required; as with `--install`, the specified file is formatted as a [python requirements file](https://pip.pypa.io/en/latest/reference/pip_install/#requirements-file-format).

You may also specify, in lieu of a pkg-file, one of two special labels:

  - ewok
  - r2d2
  
These labels refer to module-specific package files, and install _ewok_ and _r2d2_ python dependencies, respectively. For example:

```
% setv --update --package ewok <venv>
```

A venv may deleted; deleting a venv removes all traces of the venv, and it's no longer available for use. To delete a venv, enter:

```
% setv --delete <venv>
```

Working within a virtual environment does not constrain you from otherwise manipulating your python environment; rather, it means that any changes (additions, deletions, etc.) to your python environment occur **_only_** within the venv within which you're working, and do not impact your broader working environment.

## Requirements

`setv` wraps the details of installing and managing a [python virtual environment (venv)](https://docs.python.org/3/tutorial/venv.html).

A user must be able to manipulate a venv in any manner allowed regardless of what capabilities `setv` provides:

- python packages (third party libraries) installed locally in an isolated directory (as opposed to being globally installed)
- python venv activated / deactivated / deleted with common command line idioms

## Acceptance Criteria (Definition of Done)

- [x] setv is installed and loaded as a module via the jedi-stack paradigm
- [x] setv installs or updates:
  - [x] base venv:  `setv --install venv` (installs setuptools and installs / upgrades pip)
  - [x] venv with specified third-party packages: `setv --install --package <pkg-file> venv`
  - [x] venv with specified third-party packages: `setv --update --package <ewok or r2d2> venv`
  - [x] venv with ewok- and r2d2-specific libraries: `setv --update --package <ewok or r2d2> venv`
- [x] setv deletes a venv: `setv --delete venv`
- [x] setv changes the default venv dir: `setv --venvdir dir`

- [x] a venv may be manipulated exclusive of setv:
  - [x] activate a venv: `source path-to-venv/activate`
  - [x] install packages in a venv: `pip install ...`
  - [x] deactivate a venv: `deactivate`

## Dependencies

None